### PR TITLE
Fix code scanning alert no. 5: Bad HTML filtering regexp

### DIFF
--- a/public/www/lib/angular-sanitize/angular-sanitize.js
+++ b/public/www/lib/angular-sanitize/angular-sanitize.js
@@ -175,7 +175,7 @@ var START_TAG_REGEXP =
   ATTR_REGEXP = /([\w:-]+)(?:\s*=\s*(?:(?:"((?:[^"])*)")|(?:'((?:[^'])*)')|([^>\s]+)))?/g,
   BEGIN_TAG_REGEXP = /^</,
   BEGING_END_TAGE_REGEXP = /^<\//,
-  COMMENT_REGEXP = /<!--(.*?)-->/g,
+  COMMENT_REGEXP = /<!--([\s\S]*?)-->/g,
   DOCTYPE_REGEXP = /<!DOCTYPE([^>]*?)>/i,
   CDATA_REGEXP = /<!\[CDATA\[(.*?)]]>/g,
   SURROGATE_PAIR_REGEXP = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g,


### PR DESCRIPTION
Fixes [https://github.com/leonardo-souza-dev/wl-ionic/security/code-scanning/5](https://github.com/leonardo-souza-dev/wl-ionic/security/code-scanning/5)

To fix the problem, we need to modify the regular expression to correctly match HTML comments that contain newlines. The best way to achieve this is to use a non-greedy match for any character, including newlines. This can be done by using the `[\s\S]` character class, which matches any whitespace or non-whitespace character, effectively including all characters.

1. Locate the regular expression for comments on line 178 in the file `public/www/lib/angular-sanitize/angular-sanitize.js`.
2. Replace the `.` character in the regular expression with `[\s\S]` to ensure that newlines are included in the match.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
